### PR TITLE
Return null from agent transformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /build/
 /.idea/
 /out/
+/bin/
 *.iml

--- a/src/main/java/net/lenni0451/classtransform/TransformerManager.java
+++ b/src/main/java/net/lenni0451/classtransform/TransformerManager.java
@@ -267,7 +267,7 @@ public class TransformerManager implements ClassFileTransformer {
         if (className == null) return null;
         try {
             byte[] newBytes = transform(className.replace("/", "."), classfileBuffer);
-            if (newBytes != classfileBuffer) return newBytes;
+            if (!Arrays.equals(newBytes, classfileBuffer)) return newBytes;
         } catch (Throwable t) {
             t.printStackTrace();
         }

--- a/src/main/java/net/lenni0451/classtransform/TransformerManager.java
+++ b/src/main/java/net/lenni0451/classtransform/TransformerManager.java
@@ -264,13 +264,14 @@ public class TransformerManager implements ClassFileTransformer {
      */
     @Override
     public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
-        if (className == null) return classfileBuffer;
+        if (className == null) return null;
         try {
-            return transform(className.replace("/", "."), classfileBuffer);
+            byte[] newBytes = transform(className.replace("/", "."), classfileBuffer);
+            if (newBytes != classfileBuffer) return newBytes;
         } catch (Throwable t) {
             t.printStackTrace();
         }
-        return classfileBuffer;
+        return null;
     }
 
 }


### PR DESCRIPTION
Agent transformers are supposed to return null when no changes occur. This helps the agent machinery determine if the class actually needs to be updated.