### PR TITLE
Improve transformation performance by reusing compiled `Pattern`s

### DIFF
--- a/src/main/java/net/lenni0451/classtransform/transformer/AnnotationHandler.java
+++ b/src/main/java/net/lenni0451/classtransform/transformer/AnnotationHandler.java
@@ -16,6 +16,7 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static net.lenni0451.classtransform.utils.Types.typeDescriptor;
 
@@ -24,6 +25,8 @@ import static net.lenni0451.classtransform.utils.Types.typeDescriptor;
  */
 @ParametersAreNonnullByDefault
 public abstract class AnnotationHandler {
+
+    private static final Pattern ANGLE_BRACKET = Pattern.compile("[<>]");
 
     /**
      * Handle all annotations in the transformer class.
@@ -148,7 +151,8 @@ public abstract class AnnotationHandler {
     protected MethodNode renameAndCopy(final MethodNode injectionMethod, final MethodNode targetMethod, final ClassNode transformer, final ClassNode transformedClass, final String extra) {
         this.prepareForCopy(transformer, injectionMethod);
         int i = 0;
-        String baseName = injectionMethod.name + "$" + targetMethod.name.replaceAll("[<>]", "") + "$" + extra;
+        String targetName = ANGLE_BRACKET.matcher(targetMethod.name).replaceAll(""); // Make sure method name is valid when targeting <init> and <clinit>
+        String baseName = injectionMethod.name + "$" + targetName + "$" + extra;
         do {
             injectionMethod.name = baseName + i++;
         } while (this.hasMethod(transformedClass, injectionMethod.name));

--- a/src/main/java/net/lenni0451/classtransform/transformer/types/RemovingTargetAnnotationHandler.java
+++ b/src/main/java/net/lenni0451/classtransform/transformer/types/RemovingTargetAnnotationHandler.java
@@ -35,7 +35,7 @@ public abstract class RemovingTargetAnnotationHandler<T extends Annotation> exte
     public final void transform(T annotation, TransformerManager transformerManager, ClassNode transformedClass, ClassNode transformer, MethodNode transformerMethod) {
         for (String targetCombi : this.targetCombis.apply(annotation)) {
             if (targetCombi.isEmpty()) throw new TransformerException(transformerMethod, transformer, "Target is empty");
-            if (targetCombi.matches(ASMUtils.METHOD_DECLARATION_PATTERN)) {
+            if (ASMUtils.METHOD_DECLARATION_PATTERN.matcher(targetCombi).matches()) {
                 MemberDeclaration declaration = ASMUtils.splitMemberDeclaration(targetCombi);
                 if (declaration == null) throw new TransformerException(transformerMethod, transformer, "Target is not a valid method declaration");
                 if (!transformedClass.name.equals(declaration.getOwner())) continue;


### PR DESCRIPTION
## Motivation

I'm using ClassTransform in a Minecraft mod that works *before* the NeoForge early loading screen is shown, so minimizing the time spent is crucial. This PR picks some low-hanging fruits by avoiding unnecessary compilation of regular expressions.

## Changes

This PR optimizes usages of `String#matches` and `String#replaceAll` by reusing compiled `Pattern`s.

## Performance

Measuring with `System#currentTimeMillis` the time spent on `TransformerManager#transform` I'm seeing a stable improvement of roughly 15% (2000ms -> 1650ms) in my mod, which is pretty decent for such a straightforward change.